### PR TITLE
IE-19/list-all-users + add all flag to list users

### DIFF
--- a/src/scripts/list-users.test.ts
+++ b/src/scripts/list-users.test.ts
@@ -21,7 +21,7 @@ describe('Listing all users', () => {
     };
 
     // When we attempt to list the users from the client
-    const result = await users(userService)();
+    const result = await users(userService, false)();
 
     // Then we should have a right
     expect(result).toBeRight();
@@ -44,7 +44,7 @@ describe('Listing all users', () => {
     };
 
     // When we attempt to list the users from the client
-    const result = await users(userService)();
+    const result = await users(userService, false)();
 
     // Then we should have a left
     expect(result).toEqualLeft(new Error('expected error'));
@@ -71,7 +71,8 @@ describe('Listing users within groups', () => {
     const result = await usersInGroup(
       userService,
       groupService,
-      test.group.id
+      test.group.id,
+      false
     )();
 
     // Then we should have a right
@@ -108,7 +109,8 @@ describe('Listing users within groups', () => {
     const result = await usersInGroup(
       userService,
       groupService,
-      test.group.id
+      test.group.id,
+      false
     )();
 
     // Then we should have a left
@@ -137,7 +139,8 @@ describe('Listing users within groups', () => {
     const result = await usersInGroup(
       userService,
       groupService,
-      test.group.id
+      test.group.id,
+      false
     )();
 
     // Then we should have a left
@@ -166,7 +169,8 @@ describe('Listing users within groups', () => {
     const result = await usersInGroup(
       userService,
       groupService,
-      test.group.id
+      test.group.id,
+      false
     )();
 
     // Then we should have a left

--- a/src/scripts/services/user-service.ts
+++ b/src/scripts/services/user-service.ts
@@ -134,6 +134,13 @@ export class OktaUserService {
       (group) => this.privateListUsers(group, listAll)
     );
 
+  /**
+   * Lists all users in a group or client.
+   * @param groupOrClient - Either a group or a client
+   * @param listAl - Whether to list all users or just non-deprovisioned users
+   * @link https://developer.okta.com/docs/reference/api/users/#list-all-users
+   * @returns a list of users
+   */
   readonly privateListUsers = (
     groupOrClient: TE.TaskEither<Error, okta.Group | okta.Client>,
     listAll: boolean
@@ -150,6 +157,8 @@ export class OktaUserService {
           return (
             maybeGroupOrClient
               .listUsers({
+                // Without this filter, Okta will only return non-deprovisioned users.
+                // link: https://developer.okta.com/docs/reference/api/users/#list-all-users
                 filter: listAll
                   ? Object.keys(okta.UserStatus)
                       .map((status) => `status eq "${status}"`)


### PR DESCRIPTION
add --all flag to list users operation 
* with --all flag: list all users including deprovisioned
* without --all flag: list all users excluding depovisioned users (same as before)