### PR TITLE
IE-356 + Added log retrieval command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ delete-user             okta.users.manage
 list-groups             okta.groups.read
 add-user-to-group       okta.groups.manage, okta.users.manage
 remove-user-from-group  okta.groups.manage, okta.users.manage
+logs                    okta.logs.read
 ```
 
 Attemting to run a command without the required permissions will most likely result in a 400 or 403 HTTPS error.

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,7 @@ const rootCommand = yargs
   .help();
 
 /**
- * Dynamic type for global arguments. This needs to be it's own as we use a
- * require below to import all the commands
+ * Dynamic type for global arguments.
  */
 export type RootCommand = typeof rootCommand;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import listGroups from './scripts/list-groups';
 import listUsers from './scripts/list-users';
 import ping from './scripts/ping';
 import removeUserFromGroup from './scripts/remove-user-from-group';
+import logs from './scripts/logs';
+import { ReadonlyURL } from 'readonly-types';
 
 const organisationURL = 'organisation-url';
 declare global {
@@ -24,12 +26,6 @@ declare global {
     }
   }
 }
-
-/**
- * Dynamic type for global arguments. This needs to be it's own as we use a
- * require below to import all the commands
- */
-export type RootCommand = typeof rootCommand;
 
 /**
  * Add global arguments here using the .option function.
@@ -50,12 +46,11 @@ const rootCommand = yargs
     demandOption: true,
   })
   .option(organisationURL, {
-    type: 'string',
     alias: ['org-url', 'ou'],
     describe: 'Okta URL for Organisation',
     demandOption: true,
-    coerce: async (url: string) => {
-      const result = await parseUrl(url)();
+    coerce: (url: string): ReadonlyURL => {
+      const result = parseUrl(url);
       // eslint-disable-next-line functional/no-conditional-statement
       if (E.isLeft(result)) {
         // eslint-disable-next-line functional/no-throw-statement
@@ -70,6 +65,12 @@ const rootCommand = yargs
   )
   .help();
 
+/**
+ * Dynamic type for global arguments. This needs to be it's own as we use a
+ * require below to import all the commands
+ */
+export type RootCommand = typeof rootCommand;
+
 // End users of this tool will have to import their subcommands, and call it following example subcommand.
 activateUser(rootCommand);
 addUserToGroup(rootCommand);
@@ -81,5 +82,6 @@ listGroups(rootCommand);
 listUsers(rootCommand);
 ping(rootCommand);
 removeUserFromGroup(rootCommand);
+logs(rootCommand);
 
 void rootCommand.demandCommand().strict().help().argv;

--- a/src/scripts/logs.ts
+++ b/src/scripts/logs.ts
@@ -1,0 +1,165 @@
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as E from 'fp-ts/lib/Either';
+import { RootCommand } from '..';
+import * as Console from 'fp-ts/lib/Console';
+import { pipe } from 'fp-ts/lib/function';
+import { Argv } from 'yargs';
+import { oktaReadOnlyClient } from './services/client-service';
+import { retrieveLogs } from './services/okta-service';
+import * as okta from '@okta/okta-sdk-nodejs';
+import { ReadonlyDate, ReadonlyURL, readonlyDate } from 'readonly-types';
+import { table } from 'table';
+
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+const logsTable = (logs: readonly okta.LogEvent[]): string => {
+  return table(
+    [
+      ['ID', 'Published', 'Severity', 'Type', 'Who', 'Message'],
+      // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+      ...logs.map((log: okta.LogEvent) => [
+        log.uuid,
+        log.published,
+        log.severity,
+        log.eventType,
+        log.actor.displayName,
+        log.displayMessage,
+      ]),
+    ],
+    {
+      // eslint-disable-next-line functional/functional-parameters
+      drawHorizontalLine: () => false,
+      // eslint-disable-next-line functional/functional-parameters
+      drawVerticalLine: () => false,
+    }
+  );
+};
+
+const displayLogs = (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  client: okta.Client,
+  format: 'json' | 'table',
+  limit: number,
+  query?: string,
+  filter?: string,
+  since?: ReadonlyDate,
+  until?: ReadonlyDate
+): TE.TaskEither<Error, string> =>
+  pipe(
+    retrieveLogs(client, limit, query, filter, since, until),
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+    TE.map((logEvents) =>
+      format === 'table'
+        ? logsTable(logEvents)
+        : JSON.stringify(logEvents, null, 2)
+    ),
+    TE.tapIO(Console.info)
+  );
+
+export default (
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  rootCommand: RootCommand
+) => {
+  const builderCallback = (
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+    yargs: RootCommand
+  ): Argv<
+    {
+      readonly 'client-id': string;
+    } & {
+      readonly 'private-key': string;
+    } & {
+      readonly 'organisation-url': ReadonlyURL;
+    } & {
+      readonly 'output-format': 'json' | 'table';
+    } & {
+      readonly limit: number;
+    }
+  > => {
+    return yargs
+      .option('output-format', {
+        alias: 'o',
+        type: 'string',
+        choices: ['json', 'table'] as const,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        default: 'table' as 'table' | 'json',
+        description: 'The format to output the logs in.',
+      })
+      .option('limit', {
+        alias: 'l',
+        type: 'number',
+        default: 10,
+        description: 'The number of logs to retrieve.',
+      })
+      .option('query', {
+        alias: 'q',
+        type: 'string',
+        description:
+          'The query by which the logs will be filtered (e.g. OIDC).',
+      })
+      .option('filter', {
+        alias: 'f',
+        type: 'string',
+        description:
+          'The filter by which the logs will be filtered (e.g. eventType eq "user.session.start").',
+      })
+      .option('since', {
+        type: 'string',
+        description: 'The start date of the logs to retrieve.',
+        coerce: (date: string) => readonlyDate(date),
+      })
+      .option('until', {
+        type: 'string',
+        description: 'The end date of the logs to retrieve.',
+        coerce: (date: string) => readonlyDate(date),
+      });
+  };
+
+  // eslint-disable-next-line sonarjs/prefer-immediate-return
+  const command = rootCommand.command(
+    'logs',
+    'Retrieves logs from okta',
+    builderCallback,
+    async (args: {
+      readonly clientId: string;
+      readonly privateKey: string;
+      readonly organisationUrl: ReadonlyURL;
+      readonly outputFormat: 'json' | 'table';
+      readonly limit: number;
+      readonly query?: string;
+      readonly filter?: string;
+      readonly since?: ReadonlyDate;
+      readonly until?: ReadonlyDate;
+    }) => {
+      const { clientId, privateKey } = args;
+      const client = oktaReadOnlyClient(
+        {
+          clientId,
+          privateKey,
+          orgUrl: args.organisationUrl,
+        },
+        ['logs']
+      );
+
+      const result = await displayLogs(
+        client,
+        args.outputFormat,
+        args.limit,
+        args.query,
+        args.filter,
+        args.since,
+        args.until
+      )();
+      // eslint-disable-next-line functional/no-conditional-statement
+      if (E.isLeft(result)) {
+        // eslint-disable-next-line functional/no-expression-statement
+        console.error(`Fail [${JSON.stringify(result.left, null, 2)}].`);
+        // eslint-disable-next-line functional/no-throw-statement
+        throw result.left;
+      }
+    },
+    [],
+    false
+  );
+
+  return command;
+};

--- a/src/scripts/services/okta-service.test.ts
+++ b/src/scripts/services/okta-service.test.ts
@@ -9,8 +9,8 @@ import { readonlyURL } from 'readonly-types';
 describe('Parsing url', () => {
   it.each(['https://example.okta.com', 'https://example.okta.com/'])(
     'should return a right when the url is valid',
-    async (url) => {
-      const result = await parseUrl(url)();
+    (url) => {
+      const result = parseUrl(url);
       expect(result).toEqualRight(readonlyURL(url));
     }
   );
@@ -61,8 +61,8 @@ describe('Parsing url', () => {
   ])(
     'should return a left when the url is invalid',
     // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-    async (url, issues) => {
-      const result = await parseUrl(url)();
+    (url, issues) => {
+      const result = parseUrl(url);
       expect(result).toEqualLeft(
         new Error(`Client error. Invalid URL [${url}].`)
       );

--- a/src/scripts/services/okta-service.ts
+++ b/src/scripts/services/okta-service.ts
@@ -99,9 +99,8 @@ export const retrieveLogs = (
 ) => {
   return pipe(
     TE.tryCatch(
-      // eslint-disable-next-line functional/no-return-void
       async () => {
-        // eslint-disable-next-line functional/no-let, functional/prefer-readonly-type
+        // eslint-disable-next-line functional/prefer-readonly-type
         const logs: okta.LogEvent[] = [];
         return await client
           .getLogs({


### PR DESCRIPTION
Command line options:

```
Retrieves logs from okta

Okta connection settings:
      --client-id, --cid                   Okta client ID    [string] [required]
      --private-key, --pk                  Okta private key as string form of
                                           JSON              [string] [required]
      --organisation-url, --org-url, --ou  Okta URL for Organisation  [required]

Options:
      --version        Show version number                             [boolean]
      --help           Show help                                       [boolean]
  -o, --output-format  The format to output the logs in.
                          [string] [choices: "json", "table"] [default: "table"]
  -l, --limit          The number of logs to retrieve.    [number] [default: 10]
  -q, --query          The query by which the logs will be filtered (e.g. OIDC).
                                                                        [string]
  -f, --filter         The filter by which the logs will be filtered (e.g.
                       eventType eq "user.session.start").              [string]
      --since          The start date of the logs to retrieve.          [string]
      --until          The end date of the logs to retrieve.            [string]
```

Same output in table mode:
```
 ID                                    Published                 Severity  Type                Who    Message
 649c367a-9306-11ee-906b-9f37ae57e05c  2023-12-05T00:36:56.211Z  WARN      user.session.start  Dan S  User login to Okta
 c21c865c-9306-11ee-82fb-9b4e2ab3682d  2023-12-05T00:39:33.080Z  WARN      user.session.start  Dan S  User login to Okta
```