### PR TITLE
IE-356 + Added shorthand for specifying a 'since' based on duration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "@okta/okta-sdk-nodejs": "^6.5.0",
         "@types/node-fetch": "^2.6.2",
         "chalk-table": "^1.0.2",
+        "date-fns": "^2.30.0",
         "fp-ts": "^2.16.1",
         "generate-password": "^1.7.0",
         "table": "^6.8.0",
+        "tinyduration": "^3.3.0",
         "yargs": "^17.5.1",
         "zod": "^3.22.4"
       },
@@ -4226,6 +4228,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://nexus.bdc.agiledigital.co/repository/npmjs-org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/date-format": {
@@ -11123,6 +11141,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz",
       "integrity": "sha512-HFhr+OKGIHRO6krgzEt9MqbMO98wPDzDPr1BOpM/nZCChkK40UYn8b70nSjcan4jTzDSQecy1KRVVQRohIRWrw=="
+    },
+    "node_modules/tinyduration": {
+      "version": "3.3.0",
+      "resolved": "https://nexus.bdc.agiledigital.co/repository/npmjs-org/tinyduration/-/tinyduration-3.3.0.tgz",
+      "integrity": "sha512-sLR0iVUnnnyGEX/a3jhTA0QMK7UvakBqQJFLiibiuEYL6U1L85W+qApTZj6DcL1uoWQntYuL0gExoe9NU5B3PA==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "@okta/okta-sdk-nodejs": "^6.5.0",
     "@types/node-fetch": "^2.6.2",
     "chalk-table": "^1.0.2",
+    "date-fns": "^2.30.0",
     "fp-ts": "^2.16.1",
     "generate-password": "^1.7.0",
     "table": "^6.8.0",
+    "tinyduration": "^3.3.0",
     "yargs": "^17.5.1",
     "zod": "^3.22.4"
   },

--- a/src/scripts/logs.ts
+++ b/src/scripts/logs.ts
@@ -124,7 +124,7 @@ export default (
       })
       .option('within', {
         description:
-          'The start date of the logs to retrieve, expressed as a duration to be applied to now (e.g. 1d/P1D for 1 day, 2w/P2W for two weeks).',
+          'The start date of the logs to retrieve, expressed as an ISO8601 (https://en.wikipedia.org/wiki/ISO_8601#Durations) duration to be subtracted from now (e.g. 1d/P1D for 1 day, 2w/P2W for two weeks).',
         conflicts: ['since', 'until'],
         coerce: (s: string) => {
           const durationWithP = s.startsWith('P') ? s : `P${s}`;


### PR DESCRIPTION
Add a new argument to the `logs` command:

```
      --within         The start date of the logs to retrieve, expressed as a
                       duration to be applied to now (e.g. 1d/P1D for 1 day,
                       2w/P2W for two weeks).
```

that makes it easier to retrieve some of the most recent log records.